### PR TITLE
Multiple code improvements - squid:SwitchLastCaseIsDefaultCheck, squid:S00116, squid:S00117, squid:S1066, squid:S1118

### DIFF
--- a/app/src/main/java/com/nielsmasdorp/speculum/models/yahoo_weather/Item.java
+++ b/app/src/main/java/com/nielsmasdorp/speculum/models/yahoo_weather/Item.java
@@ -9,8 +9,8 @@ import java.util.List;
 public class Item {
 
     private String title;
-    private String lat;
-    private String _long;
+    private String latitude;
+    private String longitude;
     private String link;
     private String pubDate;
     private Condition condition;
@@ -29,20 +29,20 @@ public class Item {
         this.title = title;
     }
 
-    public String getLat() {
-        return lat;
+    public String getLatitude() {
+        return latitude;
     }
 
-    public void setLat(String lat) {
-        this.lat = lat;
+    public void setLatitude(String latitude) {
+        this.latitude = latitude;
     }
 
-    public String getLong() {
-        return _long;
+    public String getLongitude() {
+        return longitude;
     }
 
-    public void setLong(String _long) {
-        this._long = _long;
+    public void setLongitude(String longitude) {
+        this.longitude = longitude;
     }
 
     public String getLink() {

--- a/app/src/main/java/com/nielsmasdorp/speculum/presenters/SetupPresenterImpl.java
+++ b/app/src/main/java/com/nielsmasdorp/speculum/presenters/SetupPresenterImpl.java
@@ -21,15 +21,15 @@ public class SetupPresenterImpl implements ISetupPresenter {
         mSetupView = new WeakReference<>(view);
         mPreferenceService = SharedPreferenceService.instance();
 
-        if (mPreferenceService.getRememberConfiguration())
-            if (mSetupView.get() != null)
-                mSetupView.get().navigateToMainActivity(mPreferenceService.getLocation(),
-                        mPreferenceService.getSubreddit(),
-                        mPreferenceService.getPollingDelay(),
-                        mPreferenceService.getCelsius(),
-                        mPreferenceService.getVoiceCommands(),
-                        true,
-                        mPreferenceService.getSimpleLayout());
+        if (mPreferenceService.getRememberConfiguration() && mSetupView.get() != null) {
+            mSetupView.get().navigateToMainActivity(mPreferenceService.getLocation(),
+                    mPreferenceService.getSubreddit(),
+                    mPreferenceService.getPollingDelay(),
+                    mPreferenceService.getCelsius(),
+                    mPreferenceService.getVoiceCommands(),
+                    true,
+                    mPreferenceService.getSimpleLayout());
+        }
     }
 
     @Override

--- a/app/src/main/java/com/nielsmasdorp/speculum/util/Constants.java
+++ b/app/src/main/java/com/nielsmasdorp/speculum/util/Constants.java
@@ -3,7 +3,7 @@ package com.nielsmasdorp.speculum.util;
 /**
  * @author Niels Masdorp (NielsMasdorp)
  */
-public class Constants {
+public final class Constants {
 
     //Query constants
     public static final String REDDIT_BASE_URL = "https://www.reddit.com/r/";
@@ -72,4 +72,6 @@ public class Constants {
     public static final String SP_VOICE_IDENTIFIER = "voiceCommands";
     public static final String SP_REMEMBER_IDENTIFIER = "rememberConfiguration";
     public static final String SP_LAYOUT_IDENTIFIER = "simpleLayout";
+
+    private Constants() {}
 }

--- a/app/src/main/java/com/nielsmasdorp/speculum/views/MainActivity.java
+++ b/app/src/main/java/com/nielsmasdorp/speculum/views/MainActivity.java
@@ -264,6 +264,8 @@ public class MainActivity extends AppCompatActivity implements IMainView, View.O
                     this.mCalendarLayout.setVisibility(View.VISIBLE);
                 }
                 break;
+            default:
+                break;
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
squid:S00116 - Field names should comply with a naming convention.
squid:S00117 - Local variable and method parameter names should comply with a naming convention.
squid:S1066 - Collapsible "if" statements should be merged.
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/rules/show/squid:S00116
https://dev.eclipse.org/sonar/rules/show/squid:S00117
https://dev.eclipse.org/sonar/rules/show/squid:S1066
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava