### PR TITLE
Multiple code improvements - squid:S00122, squid:S1151, squid:UselessParenthesesCheck

### DIFF
--- a/app/src/main/java/com/nielsmasdorp/speculum/presenters/MainPresenterImpl.java
+++ b/app/src/main/java/com/nielsmasdorp/speculum/presenters/MainPresenterImpl.java
@@ -109,7 +109,9 @@ public class MainPresenterImpl implements IMainPresenter {
                     @Override
                     public void onNext(CurrentWeather weather) {
 
-                        if (mMainView.get() != null) mMainView.get().displayCurrentWeather(weather);
+                        if (mMainView.get() != null) {
+                            mMainView.get().displayCurrentWeather(weather);
+                        }
                     }
                 }));
     }
@@ -218,12 +220,7 @@ public class MainPresenterImpl implements IMainPresenter {
                     mMainView.get().setListeningMode(Constants.KWS_SEARCH);
                     break;
                 case Constants.UPDATE_PHRASE:
-                    // update data
-                    mMainView.get().talk(Constants.UPDATE_NOTIFICATION);
-                    unSubscribe();
-                    mMainView.get().startPolling();
-                    // go to sleep again and wait for activation phrase
-                    mMainView.get().setListeningMode(Constants.KWS_SEARCH);
+                    updatePhrase();
                     break;
                 case Constants.NEWS_PHRASE:
                     //TODO implement news API
@@ -241,6 +238,15 @@ public class MainPresenterImpl implements IMainPresenter {
             }
 
         }
+    }
+
+    private void updatePhrase() {
+        // update data
+        mMainView.get().talk(Constants.UPDATE_NOTIFICATION);
+        unSubscribe();
+        mMainView.get().startPolling();
+        // go to sleep again and wait for activation phrase
+        mMainView.get().setListeningMode(Constants.KWS_SEARCH);
     }
 
     private Observable<Void> prepareAssetsForRecognizer() {

--- a/app/src/main/java/com/nielsmasdorp/speculum/presenters/SetupPresenterImpl.java
+++ b/app/src/main/java/com/nielsmasdorp/speculum/presenters/SetupPresenterImpl.java
@@ -38,9 +38,13 @@ public class SetupPresenterImpl implements ISetupPresenter {
         if (pollingDelay.equals("") || pollingDelay.equals("0"))
             pollingDelay = Constants.POLLING_DELAY_DEFAULT;
 
-        if (location.isEmpty()) location = Constants.LOCATION_DEFAULT;
+        if (location.isEmpty()) {
+            location = Constants.LOCATION_DEFAULT;
+        }
 
-        if (subreddit.isEmpty()) subreddit = Constants.SUBREDDIT_DEFAULT;
+        if (subreddit.isEmpty()) {
+            subreddit = Constants.SUBREDDIT_DEFAULT;
+        }
 
         if (rememberConfig) {
             mPreferenceService.storeConfiguration(location, subreddit, Integer.parseInt(pollingDelay), celsius, voiceCommands, rememberConfig, simpleLayout);

--- a/app/src/main/java/com/nielsmasdorp/speculum/services/YahooService.java
+++ b/app/src/main/java/com/nielsmasdorp/speculum/services/YahooService.java
@@ -37,7 +37,7 @@ public class YahooService {
         // Convert degrees to cardinal directions for wind
         String[] directions = {"N", "NE", "E", "SE", "S", "SW", "W", "NW", "N"};
         String degrees = weatherData.getWind().getDirection();
-        String direction = degrees.equals("") ? "-" : directions[(int) Math.round(((Double.parseDouble(weatherData.getWind().getDirection()) % 360) / 45))];
+        String direction = degrees.equals("") ? "-" : directions[(int) Math.round((Double.parseDouble(weatherData.getWind().getDirection()) % 360) / 45)];
 
         return Observable.just(new CurrentWeather.Builder()
                 .title(weatherData.getTitle())


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00122 - Statements should be on separate lines.
squid:S1151 - "switch case" clauses should not have too many lines.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00122
https://dev.eclipse.org/sonar/rules/show/squid:S1151
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava